### PR TITLE
Refactor: Eliminate circular self-reference in foundations

### DIFF
--- a/.github/workflows/test-bootstrap.yaml
+++ b/.github/workflows/test-bootstrap.yaml
@@ -2,9 +2,6 @@ name: Test Bootstrap
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   test-bootstrap:
@@ -24,10 +21,18 @@ jobs:
           foundations:
             disable:
               cilium: true
+              ingress: true # depends on cilium
           EOF
+
+      - name: Pull the right branch in foundations
+        run: |
+          sed -i 's/branch: .*/branch: "${{ github.ref_name }}"/g' foundations/foundations.yaml
 
       - name: Bootstrap foundations
         run: kubectl apply --namespace foundations --kustomize foundations
 
       - name: Wait for foundations to be ready
         run: kubectl wait --namespace foundations --for=condition=ready --timeout=300s helmrelease foundations
+
+      - name: Check that all releases are properly running
+        run: kubectl wait --namespace foundations --for=condition=ready --timeout=300s helmrelease --all

--- a/.github/workflows/test-bootstrap.yaml
+++ b/.github/workflows/test-bootstrap.yaml
@@ -16,19 +16,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Bootstrap flux
+        run: kubectl apply --namespace foundations --kustomize flux
+
+      - name: Create config
         run: |
-          kubectl create namespace foundations
-          kubectl create configmap foundations-config --from-file=values.yaml=/dev/stdin <<EOF
+          kubectl create configmap foundations-config --from-file=foundations.yaml=/dev/stdin --dry-run=client -oyaml <<EOF > foundations/config.yaml
+          foundations:
+            disable:
+              cilium: true
           EOF
 
-          kubectl apply --namespace foundations --kustomize flux
-          helm install --namespace foundations foundations charts/foundations
+      - name: Bootstrap foundations
+        run: kubectl apply --namespace foundations --kustomize foundations
 
-      - name: Wait for flux to be ready
-        run: |
-          kubectl wait --namespace foundations --for=condition=ready pod -l app=helm-controller --timeout=300s
-
-      # This means we entered the reconcile loop properly
-      - name: Wait for localpv-provisioner to be ready
-        run: |
-          kubectl wait --namespace foundations --for=condition=ready helmrelease openebs --timeout=300s
+      - name: Wait for foundations to be ready
+        run: kubectl wait --namespace foundations --for=condition=ready --timeout=300s helmrelease foundations

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please contact support at kraud dot cloud for support.
 ![test](https://github.com/kraudcloud/foundations/actions/workflows/test-bootstrap.yaml/badge.svg)
 ![architecture](./bootstrap/bootstrap.png)
 
-In a clean cluster, edit `bootstrap/user-skeleton.yaml` then run `./bootstrap/bootstrap.sh`
+In a clean cluster, edit `foundations/config.yaml` then run `./bootstrap/bootstrap.sh`
 
 ## Upgrading
 

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -7,12 +7,11 @@ set -ex
 # - 'helm template' is not emitting the labels helm needs to upgrade it later
 # - helm dependencies are just terrible
 
-kubectl create namespace foundations
-kubectl apply -f ${HERE}/user-skeleton.yaml
+kubectl create namespace --save-config foundations
 
 # helm repo add cilium https://helm.cilium.io/
 helm install --namespace foundations cilium cilium/cilium --version 1.15.7 --values ${HERE}/cilium-values.yaml
 
 kubectl apply --namespace foundations --kustomize ${HERE}/../flux
 
-helm install --namespace foundations foundations ${HERE}/../charts/foundations
+kubectl apply --namespace foundations --kustomize ${HERE}/../foundations

--- a/charts/foundations/Chart.yaml
+++ b/charts/foundations/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.17
+version: 0.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,4 +16,3 @@ data:
     #     publicIPs:
     #       - cidr: 192.168.181.1/32
     #       - cidr: 192.168.181.2/32
-

--- a/foundations/foundations.yaml
+++ b/foundations/foundations.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: remove-self-reference
+    branch: main
   url: https://github.com/kraudcloud/foundations.git
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/foundations/foundations.yaml
+++ b/foundations/foundations.yaml
@@ -1,24 +1,20 @@
----
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: foundations
-  namespace: foundations
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: remove-self-reference
   url: https://github.com/kraudcloud/foundations.git
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: foundations
-  namespace: foundations
 spec:
-  releaseName: foundations
   serviceAccountName: flux-admin
-  interval: 1h0m0s
+  interval: 10m0s
   install:
     remediation:
       retries: 3
@@ -32,7 +28,6 @@ spec:
       sourceRef:
         kind: GitRepository
         name: foundations
-        namespace: foundations
   valuesFrom:
     - kind: ConfigMap
       name: foundations-config
@@ -42,7 +37,6 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: foundations-config
-  namespace: foundations
 spec:
   releaseName: foundations-config
   serviceAccountName: flux-admin
@@ -60,7 +54,6 @@ spec:
       sourceRef:
         kind: GitRepository
         name: foundations
-        namespace: foundations
   dependsOn:
     - name: foundations
   valuesFrom:

--- a/foundations/foundations.yaml
+++ b/foundations/foundations.yaml
@@ -2,6 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: foundations
+  namespace: foundations
 spec:
   interval: 1m0s
   ref:
@@ -12,9 +13,11 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: foundations
+  namespace: foundations
 spec:
+  releaseName: foundations
   serviceAccountName: flux-admin
-  interval: 10m0s
+  interval: 1h0m0s
   install:
     remediation:
       retries: 3
@@ -28,6 +31,7 @@ spec:
       sourceRef:
         kind: GitRepository
         name: foundations
+        namespace: foundations
   valuesFrom:
     - kind: ConfigMap
       name: foundations-config
@@ -37,6 +41,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: foundations-config
+  namespace: foundations
 spec:
   releaseName: foundations-config
   serviceAccountName: flux-admin
@@ -54,6 +59,7 @@ spec:
       sourceRef:
         kind: GitRepository
         name: foundations
+        namespace: foundations
   dependsOn:
     - name: foundations
   valuesFrom:

--- a/foundations/kustomization.yaml
+++ b/foundations/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
+  - config.yaml
   - foundations.yaml

--- a/foundations/kustomization.yaml
+++ b/foundations/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - foundations.yaml


### PR DESCRIPTION
This PR eliminates the unnecessary self-reference in the foundations chart.

It also significantly overhauls the CI to make sure *all* sub-components are ready.

Only cilium and the ingress are not covered by the CI, as the ingress depends on cilium, and cilium won't run in CI.