### PR TITLE
feat: add klum for managing users

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,22 @@
 KRAUD CLOUD ENTERPRISE FOUNDATIONS
 ==================================
 
-
 An opinionated foundational set of services for managed kubernetes.
 We manage, tests, audits and support this stack for our customer clusters.
 It is available to the public as a learning example only.
 Pull requests will be ignored.
 Please contact support at kraud dot cloud for support.
 
-
-| chart        | version | license      | grade |
-|--------------|---------|--------------|-------|
-| cert-manager | 1.15    | Apache 2.0   | A     |
-| cilium       | 1.15    | Apache 2.0   | A     | 
-| flux         | 2.3     | Apache 2.0   | A     | 
-| haproxy      | 1.4     | GPL-         | A     | 
-| longhorn     | 1.6     | Apache 2.0   | B     | 
-| openebs      | 4.1     | Apache 2.0   | B     | 
-| prometheus   | 56.8    | Apache 2.0   | B     |
-
-
+| chart                                  | version | license    | grade |
+| -------------------------------------- | ------- | ---------- | ----- |
+| cert-manager                           | 1.15    | Apache 2.0 | A     |
+| cilium                                 | 1.15    | Apache 2.0 | A     |
+| flux                                   | 2.3     | Apache 2.0 | A     |
+| [klum](https://github.com/jadolg/klum) | 0.8.1   | Apache 2.0 | A     |
+| haproxy                                | 1.4     | GPL-       | A     |
+| longhorn                               | 1.6     | Apache 2.0 | B     |
+| openebs                                | 4.1     | Apache 2.0 | B     |
+| prometheus                             | 56.8    | Apache 2.0 | B     |
 
 ## Bootstrapping
 

--- a/charts/foundations-config/templates/cilium-config.yaml
+++ b/charts/foundations-config/templates/cilium-config.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.foundations }}
-{{- if .Values.foundations.cloud }}
+{{- if (.Values.foundations).cloud }}
 ---
 apiVersion: "cilium.io/v2alpha1"
 kind: CiliumBGPPeeringPolicy
@@ -25,6 +24,5 @@ metadata:
 spec:
   blocks: {{ .Values.foundations.cloud.publicIPs | toYaml | nindent 4 }}
 ---
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/foundations/Chart.yaml
+++ b/charts/foundations/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.18
+version: 0.1.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/foundations/templates/_helpers.tpl
+++ b/charts/foundations/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{/*
+clusterComponent returns a formatted cluster address based on the clusterDomain
+
+Usage:
+    {{include "clusterComponent" (list "k8s" .)}}
+*/}}
+{{- define "clusterComponent" -}}
+{{- printf "https://%s.%s" (first .) ((last .).Values.foundations).clusterDomain -}}
+{{- end -}}

--- a/charts/foundations/templates/cilium.yaml
+++ b/charts/foundations/templates/cilium.yaml
@@ -1,4 +1,4 @@
-{{- if or (not .Values.foundations) (not .Values.foundations.disable) (not .Values.foundations.disable.cilium)  }}
+{{- if not ((.Values.foundations).disable).cilium }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/charts/foundations/templates/ingress.yaml
+++ b/charts/foundations/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if or (not .Values.foundations) (not .Values.foundations.disable) (not .Values.foundations.disable.ingress)  }}
+{{- if not ((.Values.foundations).disable).ingress }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -30,15 +30,9 @@ spec:
         enabled: true
         type: LoadBalancer
         externalTrafficPolicy: Local
-        {{- if .Values.foundations }}
-        {{- if .Values.foundations.ingress }}
-        {{- if .Values.foundations.ingress.public }}
-        {{- if .Values.foundations.ingress.public.IP }}
+        {{- if (((.Values.foundations).ingress).public).IP }}
         annotations:
           io.cilium/lb-ipam-ips: "{{ .Values.foundations.ingress.public.IP }}"
-        {{- end }}
-        {{- end }}
-        {{- end }}
         {{- end }}
         loadBalancerClass: io.cilium/bgp-control-plane
 

--- a/charts/foundations/templates/klum.yaml
+++ b/charts/foundations/templates/klum.yaml
@@ -14,8 +14,6 @@ spec:
     # include deploy.yaml
     !/deploy.yaml
 ---
-{{/* Makes sure nothing crashes while keeping all defaults empty and the code simple */}}
-{{- if not .Values.klum }}{{- set .Values "klum" (dict) }}{{ end }}
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -38,12 +36,16 @@ spec:
         - op: replace
           path: /spec/template/spec/containers/0/env
           value:
+            {{- $clusterCode := "kubernetes" }}
+            {{- $clusterAddress := "https://localhost:4443" }}
+            {{- if and .Values.foundations .Values.foundations.clusterCode }}{{ $clusterCode = .Values.foundations.clusterCode }}{{- end }}
+            {{- if and .Values.foundations .Values.foundations.clusterAddress }}{{ $clusterAddress = .Values.foundations.clusterAddress }}{{- end }}
             - name: CONTEXT_NAME
-              value: {{ .Values.klum.contextName | default "kubernetes" | quote }}
+              value: {{ quote $clusterCode }}
             - name: SERVER_NAME
-              value: {{ .Values.klum.serverAddress | default "https://localhost:4443" | quote }}
+              value: {{ quote $clusterAddress }}
             - name: NAMESPACE
-              value: {{ .Release.Namespace | quote }}
+              value: {{ quote .Release.Namespace }}
             - name: DEFAULT_CLUSTER_ROLE
               value: "view"
 {{ end }}

--- a/charts/foundations/templates/klum.yaml
+++ b/charts/foundations/templates/klum.yaml
@@ -14,8 +14,8 @@ spec:
     # include deploy.yaml
     !/deploy.yaml
 ---
-# Makes sure nothing crashes while keeping all defaults empty and the code simple
-# {{- if not .Values.klum }}{{- set .Values "klum" (dict) }}{{ end }}
+{{/* Makes sure nothing crashes while keeping all defaults empty and the code simple */}}
+{{- if not .Values.klum }}{{- set .Values "klum" (dict) }}{{ end }}
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/charts/foundations/templates/klum.yaml
+++ b/charts/foundations/templates/klum.yaml
@@ -43,7 +43,7 @@ spec:
             - name: SERVER_NAME
               value: {{ .Values.klum.serverAddress | default "https://localhost:4443" | quote }}
             - name: NAMESPACE
-              value: {{ .Values.klum.namespace | default .Release.Namespace | quote }}
+              value: {{ .Release.Namespace | quote }}
             - name: DEFAULT_CLUSTER_ROLE
-              value: {{ .Values.klum.defaultRole | default "view" | quote }}
+              value: "view"
 {{ end }}

--- a/charts/foundations/templates/klum.yaml
+++ b/charts/foundations/templates/klum.yaml
@@ -1,0 +1,47 @@
+{{- if or (not .Values.foundations) (not .Values.foundations.disable) (not .Values.foundations.disable.klum) }}
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: klum
+spec:
+  interval: 30m
+  url: https://github.com/jadolg/klum
+  ref:
+    tag: v0.8.1
+  ignore: |
+    # exclude all
+    /*
+    # include deploy.yaml
+    !/deploy.yaml
+---
+# Makes sure nothing crashes while keeping all defaults empty and the code simple
+# {{- if not .Values.klum }}{{- set .Values "klum" (dict) }}{{ end }}
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: klum
+  namespace: foundations
+spec:
+  targetNamespace: foundations
+  serviceAccountName: flux-admin
+  interval: 1h
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: klum
+    namespace: foundations
+  patches:
+    - target:
+        kind: Deployment
+        name: klum
+      patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/env
+          value:
+            - name: CONTEXT_NAME
+              value: {{ .Values.klum.contextName | default "kubernetes" | quote }}
+            - name: SERVER_NAME
+              value: {{ .Values.klum.serverAddress | default "https://localhost:4443" | quote }}
+            - name: NAMESPACE
+              value: {{ .Values.klum.namespace | default .Release.Namespace | quote }}
+{{ end }}

--- a/charts/foundations/templates/klum.yaml
+++ b/charts/foundations/templates/klum.yaml
@@ -37,9 +37,9 @@ spec:
           path: /spec/template/spec/containers/0/env
           value:
             - name: CONTEXT_NAME
-              value: {{ default "kubernetes" (.Values.foundations).clusterCode | quote }}
+              value: {{ default "kubernetes" (.Values.foundations).intranetDomain | quote }}
             - name: SERVER_NAME
-              value: {{ default "https://localhost:4443" (.Values.foundations).clusterAddress | quote }}
+              value: {{ include "clusterComponent" (list "k8s" .) | quote }}
             - name: NAMESPACE
               value: {{ quote .Release.Namespace }}
             - name: DEFAULT_CLUSTER_ROLE

--- a/charts/foundations/templates/klum.yaml
+++ b/charts/foundations/templates/klum.yaml
@@ -25,7 +25,7 @@ spec:
   targetNamespace: foundations
   serviceAccountName: flux-admin
   interval: 1h
-  prune: true
+  prune: false
   sourceRef:
     kind: GitRepository
     name: klum

--- a/charts/foundations/templates/klum.yaml
+++ b/charts/foundations/templates/klum.yaml
@@ -44,4 +44,6 @@ spec:
               value: {{ .Values.klum.serverAddress | default "https://localhost:4443" | quote }}
             - name: NAMESPACE
               value: {{ .Values.klum.namespace | default .Release.Namespace | quote }}
+            - name: DEFAULT_CLUSTER_ROLE
+              value: {{ .Values.klum.defaultRole | default "view" | quote }}
 {{ end }}

--- a/charts/foundations/templates/klum.yaml
+++ b/charts/foundations/templates/klum.yaml
@@ -1,4 +1,4 @@
-{{- if or (not .Values.foundations) (not .Values.foundations.disable) (not .Values.foundations.disable.klum) }}
+{{- if not ((.Values.foundations).disable).klum }}
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -36,14 +36,10 @@ spec:
         - op: replace
           path: /spec/template/spec/containers/0/env
           value:
-            {{- $clusterCode := "kubernetes" }}
-            {{- $clusterAddress := "https://localhost:4443" }}
-            {{- if and .Values.foundations .Values.foundations.clusterCode }}{{ $clusterCode = .Values.foundations.clusterCode }}{{- end }}
-            {{- if and .Values.foundations .Values.foundations.clusterAddress }}{{ $clusterAddress = .Values.foundations.clusterAddress }}{{- end }}
             - name: CONTEXT_NAME
-              value: {{ quote $clusterCode }}
+              value: {{ default "kubernetes" (.Values.foundations).clusterCode | quote }}
             - name: SERVER_NAME
-              value: {{ quote $clusterAddress }}
+              value: {{ default "https://localhost:4443" (.Values.foundations).clusterAddress | quote }}
             - name: NAMESPACE
               value: {{ quote .Release.Namespace }}
             - name: DEFAULT_CLUSTER_ROLE

--- a/charts/foundations/templates/longhorn.yaml
+++ b/charts/foundations/templates/longhorn.yaml
@@ -1,4 +1,4 @@
-{{- if or (not .Values.foundations) (not .Values.foundations.disable) (not .Values.foundations.disable.longhorn)  }}
+{{- if not ((.Values.foundations).disable).longhorn }}
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/charts/foundations/templates/openebs.yaml
+++ b/charts/foundations/templates/openebs.yaml
@@ -1,4 +1,4 @@
-{{- if or (not .Values.foundations) (not .Values.foundations.disable) (not .Values.foundations.disable.openebs)  }}
+{{- if not ((.Values.foundations).disable).openebs }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -6,8 +6,8 @@ metadata:
 data:
   foundations.yaml: |
     foundations:
-    #  clusterCode: "bocchi"
-    #  clusterAddress: "https://k8s.bocchi.rocks:4443"
+      clusterName: "bocchi"
+      intranetDomain: "bocchi.rocks" # results in cluster address being `https://k8s.bocchi.rocks`
     #  disable:
     #    cilium: true
     #    longhorn: true

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -20,5 +20,3 @@ data:
     #  klum:
     #    contextName: "kubernetes"
     #    serverAddress: "https://localhost:4443"
-    #    namespace: "foundations"
-    #    defaultRole: "view"

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -21,3 +21,4 @@ data:
     #    contextName: "kubernetes"
     #    serverAddress: "https://localhost:4443"
     #    namespace: "foundations"
+    #    defaultRole: "view"

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -6,6 +6,8 @@ metadata:
 data:
   foundations.yaml: |
     foundations:
+    #  clusterCode: "bocchi"
+    #  clusterAddress: "https://k8s.bocchi.rocks:4443"
     #  disable:
     #    cilium: true
     #    longhorn: true
@@ -17,6 +19,3 @@ data:
     #     publicIPs:
     #       - cidr: 192.168.181.1/32
     #       - cidr: 192.168.181.2/32
-    #  klum:
-    #    contextName: "kubernetes"
-    #    serverAddress: "https://localhost:4443"

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -11,8 +11,13 @@ data:
     #    longhorn: true
     #    openebs: true
     #    ingress: true
+    #    klum: true
     #  cloud:
     #     region: ber1
     #     publicIPs:
     #       - cidr: 192.168.181.1/32
     #       - cidr: 192.168.181.2/32
+    #  klum:
+    #    contextName: "kubernetes"
+    #    serverAddress: "https://localhost:4443"
+    #    namespace: "foundations"


### PR DESCRIPTION
Add klum by default for managing users in a kubernetes cluster.

Klum configuration is fairly simple but pretty important to actually output decent kubeconfig files, so I've kept it right under `foundations`. It's possible to easily move the config around.