### PR TITLE
fix(klum): wrong variable names

### DIFF
--- a/charts/foundations/Chart.yaml
+++ b/charts/foundations/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.19
+version: 0.1.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/foundations/templates/_helpers.tpl
+++ b/charts/foundations/templates/_helpers.tpl
@@ -5,5 +5,5 @@ Usage:
     {{include "clusterComponent" (list "k8s" .)}}
 */}}
 {{- define "clusterComponent" -}}
-{{- printf "https://%s.%s" (first .) ((last .).Values.foundations).clusterDomain -}}
+{{- printf "https://%s.%s" (first .) ((last .).Values.foundations).intranetDomain -}}
 {{- end -}}

--- a/charts/foundations/templates/klum.yaml
+++ b/charts/foundations/templates/klum.yaml
@@ -37,7 +37,7 @@ spec:
           path: /spec/template/spec/containers/0/env
           value:
             - name: CONTEXT_NAME
-              value: {{ default "kubernetes" (.Values.foundations).intranetDomain | quote }}
+              value: {{ default "kubernetes" (.Values.foundations).clusterName | quote }}
             - name: SERVER_NAME
               value: {{ include "clusterComponent" (list "k8s" .) | quote }}
             - name: NAMESPACE


### PR DESCRIPTION
the wrong variable names were both in helpers and klum. Probably got tired of changing them and missed some. It is fixed now.

One downside of making everything optional and no default value is that we lose any form of linting, which would have catched that. We could revise our policy in `charts/foundations/values.yaml` to make it easier to catch these.