### PR TITLE
fix ingress policy to allow internal sources

### DIFF
--- a/charts/foundations/templates/ingress-network-policy.yaml
+++ b/charts/foundations/templates/ingress-network-policy.yaml
@@ -12,9 +12,7 @@ spec:
   - Ingress
   - Egress
   ingress:
-  - from:
-    - ipBlock:
-        cidr: 0.0.0.0/0
+  - {}
   egress:
   - to:
     - ipBlock:


### PR DESCRIPTION
javascript developers love using external ingress instead of internal, so we have to accoutn for the source of a packet towards ingress having a cilium identity. confusing cidr: 0.0.0.0/0 is not matched against identities. instead we want an empty filter