### PR TITLE
fix(klum)!: move users to the klum ns instead of foundations

### DIFF
--- a/charts/foundations/Chart.yaml
+++ b/charts/foundations/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.20
+version: 0.1.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/foundations/templates/klum.yaml
+++ b/charts/foundations/templates/klum.yaml
@@ -1,4 +1,9 @@
 {{- if not ((.Values.foundations).disable).klum }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: klum
+---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -41,7 +46,7 @@ spec:
             - name: SERVER_NAME
               value: {{ include "clusterComponent" (list "k8s" .) | quote }}
             - name: NAMESPACE
-              value: "default"
+              value: "klum"
             - name: DEFAULT_CLUSTER_ROLE
               value: "view"
 {{ end }}

--- a/charts/foundations/templates/klum.yaml
+++ b/charts/foundations/templates/klum.yaml
@@ -41,7 +41,7 @@ spec:
             - name: SERVER_NAME
               value: {{ include "clusterComponent" (list "k8s" .) | quote }}
             - name: NAMESPACE
-              value: {{ quote .Release.Namespace }}
+              value: "default"
             - name: DEFAULT_CLUSTER_ROLE
               value: "view"
 {{ end }}


### PR DESCRIPTION
Using `foundations` `Namespace` means we might have user `ServiceAccount`s conflicts with existing `ServiceAccount`s in the `foundations` `Namespace`.

`default` has no other `ServiceAccount by default, and always exists, which avoids us creating yet another `Namespace`.

This change is breaking, as users will have their credentials rotated.