### PR TITLE
feat(prometheus): remote_write configuration

### DIFF
--- a/.github/workflows/test-bootstrap.yaml
+++ b/.github/workflows/test-bootstrap.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Create config
         run: |
-          kubectl create configmap foundations-config --from-file=foundations.yaml=/dev/stdin --dry-run=client -oyaml <<EOF > foundations/config.yaml
+          cat <<EOF > foundations/config.yaml
           foundations:
             disable:
               cilium: true

--- a/charts/foundations/Chart.yaml
+++ b/charts/foundations/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.21
+version: 0.1.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/foundations/templates/prometheus.yaml
+++ b/charts/foundations/templates/prometheus.yaml
@@ -26,6 +26,15 @@ spec:
   values:
     grafana:
       enabled: false
+    {{ if ((.Values.foundations).cloud).metricsCollectorUri }}
+    prometheus:
+      prometheusSpec:
+        remoteWrite:
+          - url: {{ .Values.foundations.cloud.metricsCollectorUri | quote }}
+            name: collector
+            headers:
+              X-Scope-OrgID: {{ .Values.foundations.clusterName | quote }}
+    {{ end }}
   install:
     createNamespace: true
   upgrade:

--- a/charts/foundations/templates/prometheus.yaml
+++ b/charts/foundations/templates/prometheus.yaml
@@ -29,11 +29,25 @@ spec:
     {{ if ((.Values.foundations).cloud).metricsCollectorUri }}
     prometheus:
       prometheusSpec:
+        basicAuth:
+          username: {{ .Values.foundations.clusterName }}
+          passwordFile: "/etc/metrics-collector/password"
         remoteWrite:
           - url: {{ .Values.foundations.cloud.metricsCollectorUri | quote }}
             name: collector
             headers:
               X-Scope-OrgID: {{ .Values.foundations.clusterName | quote }}
+        volumes:
+          - name: metrics-collector-secret
+            secret:
+              secretName: metrics-collector-secret
+              items:
+                - key: password
+                  path: password
+        volumeMounts:
+          - name: metrics-collector-secret
+            mountPath: /etc/metrics-collector
+            readOnly: true
     {{ end }}
   install:
     createNamespace: true

--- a/charts/foundations/templates/prometheus.yaml
+++ b/charts/foundations/templates/prometheus.yaml
@@ -29,25 +29,20 @@ spec:
     {{ if ((.Values.foundations).cloud).metricsCollectorUri }}
     prometheus:
       prometheusSpec:
-        basicAuth:
-          username: {{ .Values.foundations.clusterName }}
-          passwordFile: "/etc/metrics-collector/password"
         remoteWrite:
           - url: {{ .Values.foundations.cloud.metricsCollectorUri | quote }}
             name: collector
             headers:
               X-Scope-OrgID: {{ .Values.foundations.clusterName | quote }}
-        volumes:
-          - name: metrics-collector-secret
-            secret:
-              secretName: metrics-collector-secret
-              items:
-                - key: password
-                  path: password
-        volumeMounts:
-          - name: metrics-collector-secret
-            mountPath: /etc/metrics-collector
-            readOnly: true
+            {{ if ((.Values.foundations).cloud).metricsCollectorPassword }}
+            basicAuth:
+              username:
+                name: metrics-collector-secret
+                key: username
+              password:
+                name: metrics-collector-secret
+                key: password
+            {{ end }}
     {{ end }}
   install:
     createNamespace: true
@@ -55,12 +50,13 @@ spec:
     remediation:
       remediateLastFailure: true
 ---
-{{ if ((.Values.foundations).cloud).metricsCollectorUri }}
+{{ if and ((.Values.foundations).cloud).metricsCollectorUri .Values.foundations.cloud.metricsCollectorPassword }}
 apiVersion: v1
 kind: Secret
 metadata:
   namespace: foundations
   name: metrics-collector-secret
 stringData:
+  username: {{ .Values.foundations.clusterName | quote }}
   password: {{ .Values.foundations.cloud.metricsCollectorPassword | quote }}
 {{ end }}

--- a/charts/foundations/templates/prometheus.yaml
+++ b/charts/foundations/templates/prometheus.yaml
@@ -54,3 +54,13 @@ spec:
   upgrade:
     remediation:
       remediateLastFailure: true
+---
+{{ if ((.Values.foundations).cloud).metricsCollectorUri }}
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: foundations
+  name: metrics-collector-secret
+stringData:
+  password: {{ .Values.foundations.cloud.metricsCollectorPassword | quote }}
+{{ end }}

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -20,3 +20,13 @@ data:
     #       - cidr: 192.168.181.1/32
     #       - cidr: 192.168.181.2/32
     #     metricsCollectorUri: "http://<cortex>/prometheus/api/v1/push"
+---
+# If you enable metricsCollector, and it's properly configured
+# for basic_auth with that cluster name & a password, you can create this secret
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: foundations
+  name: metrics-collector-secret
+stringData:
+  password: ""

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -1,23 +1,16 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: foundations
-  name: foundations-config
-data:
-  foundations.yaml: |
-    foundations:
-      clusterName: "bocchi"
-      intranetDomain: "bocchi.rocks" # results in cluster address being `https://k8s.bocchi.rocks`
-    #  disable:
-    #    cilium: true
-    #    longhorn: true
-    #    openebs: true
-    #    ingress: true
-    #    klum: true
-    #  cloud:
-    #     region: ber1
-    #     publicIPs:
-    #       - cidr: 192.168.181.1/32
-    #       - cidr: 192.168.181.2/32
-    #     metricsCollectorUri: "http://<cortex>/prometheus/api/v1/push"
-    #     metricsCollectorPassword: ""
+foundations:
+  clusterName: "bocchi"
+  intranetDomain: "bocchi.rocks" # results in cluster address being `https://k8s.bocchi.rocks`
+  # disable:
+  #   cilium: true
+  #   longhorn: true
+  #   openebs: true
+  #   ingress: true
+  #   klum: true
+  # cloud:
+  #   region: ber1
+  #   publicIPs:
+  #     - cidr: 192.168.181.1/32
+  #     - cidr: 192.168.181.2/32
+  #   metricsCollectorUri: "http://<cortex>/prometheus/api/v1/push"
+  #   metricsCollectorPassword: ""

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -20,13 +20,4 @@ data:
     #       - cidr: 192.168.181.1/32
     #       - cidr: 192.168.181.2/32
     #     metricsCollectorUri: "http://<cortex>/prometheus/api/v1/push"
----
-# If you enable metricsCollector, and it's properly configured
-# for basic_auth with that cluster name & a password, you can create this secret
-apiVersion: v1
-kind: Secret
-metadata:
-  namespace: foundations
-  name: metrics-collector-secret
-stringData:
-  password: ""
+    #     metricsCollectorPassword: ""

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -19,3 +19,4 @@ data:
     #     publicIPs:
     #       - cidr: 192.168.181.1/32
     #       - cidr: 192.168.181.2/32
+    #     metricsCollectorUri: "http://<cortex>/prometheus/api/v1/push"

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -12,5 +12,5 @@ foundations:
   #   publicIPs:
   #     - cidr: 192.168.181.1/32
   #     - cidr: 192.168.181.2/32
-  #   metricsCollectorUri: "http://<cortex>/prometheus/api/v1/push"
+  #   metricsCollectorUri: "http://<cortex>"
   #   metricsCollectorPassword: ""

--- a/foundations/foundations.yaml
+++ b/foundations/foundations.yaml
@@ -33,10 +33,6 @@ spec:
         name: foundations
         namespace: foundations
   valuesFrom:
-    - kind: ConfigMap
-      name: foundations-config
-      valuesKey: foundations.yaml
-      optional: true
     - kind: Secret
       name: foundations-config
       valuesKey: foundations.yaml
@@ -67,10 +63,6 @@ spec:
   dependsOn:
     - name: foundations
   valuesFrom:
-    - kind: ConfigMap
-      name: foundations-config
-      valuesKey: foundations.yaml
-      optional: true
     - kind: Secret
       name: foundations-config
       valuesKey: foundations.yaml

--- a/foundations/foundations.yaml
+++ b/foundations/foundations.yaml
@@ -36,6 +36,9 @@ spec:
     - kind: ConfigMap
       name: foundations-config
       valuesKey: foundations.yaml
+    - kind: Secret
+      name: foundations-config
+      valuesKey: foundations.yaml
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/foundations/foundations.yaml
+++ b/foundations/foundations.yaml
@@ -36,6 +36,7 @@ spec:
     - kind: ConfigMap
       name: foundations-config
       valuesKey: foundations.yaml
+      optional: true
     - kind: Secret
       name: foundations-config
       valuesKey: foundations.yaml
@@ -67,5 +68,9 @@ spec:
     - name: foundations
   valuesFrom:
     - kind: ConfigMap
+      name: foundations-config
+      valuesKey: foundations.yaml
+      optional: true
+    - kind: Secret
       name: foundations-config
       valuesKey: foundations.yaml

--- a/foundations/kustomization.yaml
+++ b/foundations/kustomization.yaml
@@ -1,3 +1,10 @@
 resources:
-  - config.yaml
   - foundations.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+secretGenerator:
+  - name: foundations-config
+    files:
+      - foundations.yaml=config.yaml


### PR DESCRIPTION
changes are:
- backwards compatible
- automatically applicable
- switch to a proper k8s secret for security reasons.

it might not make a huge difference but it didn't sit right with me to just drop a password in a configmap.

this secret you will need to encrypt and decrypt anyways (eg through flux+sops), or using a secret-provider (in which case there would be no way to handle without it being a configmap)