### PR TITLE
feat(monitoring): add flux podmonitor

### DIFF
--- a/charts/foundations-config/Chart.yaml
+++ b/charts/foundations-config/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/foundations-config/templates/flux-monitoring.yaml
+++ b/charts/foundations-config/templates/flux-monitoring.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: flux-system
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - helm-controller
+          - source-controller
+          - kustomize-controller
+          - notification-controller
+          - image-automation-controller
+          - image-reflector-controller
+  podMetricsEndpoints:
+    - port: http-prom


### PR DESCRIPTION
Add a podmonitor allowing us to gather metrics from the deployed flux components.

See https://fluxcd.io/flux/monitoring/metrics/#monitoring-setup to get the grafana dashboards set-up.