### PR TITLE
fix!: fix foundations semver

### DIFF
--- a/.github/workflows/fixup-chart.yaml
+++ b/.github/workflows/fixup-chart.yaml
@@ -1,0 +1,51 @@
+name: Fixup Chart Versions
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  fixup-chart:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update Chart.yaml files
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+
+          update_chart() {
+            local file=$1
+            if ! grep -q "version: $VERSION" "$file"; then
+              sed -i "s/^version:.*/version: $VERSION/" "$file"!@
+              echo "Updated $file"
+              git add "$file"
+              CHANGED=1
+            fi
+          }
+
+          update_chart "charts/foundations-config/Chart.yaml"
+          update_chart "charts/foundations/Chart.yaml"
+
+          if [ "$CHANGED" = "1" ]; then
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git commit -m "Update Chart versions to $VERSION"
+            git push origin HEAD:${GITHUB_REF} --force
+          else
+            echo "No changes needed"
+          fi
+
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.8.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          force: true

--- a/.github/workflows/test-bootstrap.yaml
+++ b/.github/workflows/test-bootstrap.yaml
@@ -24,9 +24,18 @@ jobs:
               ingress: true # depends on cilium
           EOF
 
-      - name: Pull the right branch in foundations
+      - name: Patch foundations kustomization
         run: |
-          sed -i 's/branch: .*/branch: "${{ github.ref_name }}"/g' foundations/foundations.yaml
+          cat <<EOF >> foundations/kustomization.yaml
+          patches:
+            - target:
+                kind: GitRepository
+              patch: |-
+                - op: replace
+                  path: /spec/ref
+                  value:
+                    branch: "${{ github.ref_name }}"
+          EOF
 
       - name: Bootstrap foundations
         run: kubectl apply --namespace foundations --kustomize foundations

--- a/.github/workflows/test-bootstrap.yaml
+++ b/.github/workflows/test-bootstrap.yaml
@@ -11,6 +11,8 @@ jobs:
       - uses: azure/setup-kubectl@v3
       - uses: helm/kind-action@v1
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Bootstrap flux
         run: kubectl apply --namespace foundations --kustomize flux

--- a/foundations/foundations.yaml
+++ b/foundations/foundations.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    semver: "0.1.x"
   url: https://github.com/kraudcloud/foundations.git
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -27,7 +27,6 @@ spec:
   chart:
     spec:
       chart: charts/foundations
-      version: "0.1.*"
       sourceRef:
         kind: GitRepository
         name: foundations
@@ -55,7 +54,6 @@ spec:
   chart:
     spec:
       chart: charts/foundations-config
-      version: "0.1.*"
       sourceRef:
         kind: GitRepository
         name: foundations

--- a/foundations/kustomization.yaml
+++ b/foundations/kustomization.yaml
@@ -1,3 +1,4 @@
+namespace: foundations
 resources:
   - foundations.yaml
 


### PR DESCRIPTION
To avoid automatically upgrading everything, existing deployments must fix their foundations gitrepository configuration such that it points to proper semver tags, instead of targeting main.