### PR TITLE
feat(alertcollector): send alerts to a remote alertmanager

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: azure/setup-helm@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install helm unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.6.1
+      - name: Run unittest
+        run: helm unittest charts/foundations

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 kubeconfig.yaml
+__snapshot__

--- a/charts/foundations-config/templates/cilium-config.yaml
+++ b/charts/foundations-config/templates/cilium-config.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.foundations).cloud }}
+{{- if and (.Values.foundations).cloud (not ((.Values.foundations).disable).cilium ) }}
 ---
 apiVersion: "cilium.io/v2alpha1"
 kind: CiliumBGPPeeringPolicy

--- a/charts/foundations/Chart.yaml
+++ b/charts/foundations/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/foundations/templates/prometheus.yaml
+++ b/charts/foundations/templates/prometheus.yaml
@@ -26,9 +26,17 @@ spec:
   values:
     grafana:
       enabled: false
-    {{ if ((.Values.foundations).cloud).metricsCollectorUri }}
+    alertmanager:
+      enabled: {{ eq (((.Values.foundations).cloud).alertsCollectorUri) nil }}
     prometheus:
       prometheusSpec:
+        podMonitorSelectorNilUsesHelmValues: false
+        serviceMonitorSelectorNilUsesHelmValues: false
+        scrapeConfigSelectorNilUsesHelmValues: false
+        probeSelectorNilUsesHelmValues: false
+        externalLabels:
+          cluster: {{ .Values.foundations.clusterName | quote }}
+        {{ if ((.Values.foundations).cloud).metricsCollectorUri }}
         remoteWrite:
           - url: {{ .Values.foundations.cloud.metricsCollectorUri | quote }}
             name: collector
@@ -43,7 +51,27 @@ spec:
                 name: metrics-collector-secret
                 key: password
             {{ end }}
-    {{ end }}
+        {{ end }}
+        {{ if ((.Values.foundations).cloud).alertsCollectorUri }}
+        {{ if ((.Values.foundations).cloud).alertsCollectorPassword }}
+        secrets:
+          - alerts-collector-secret
+        {{ end }}
+        additionalAlertManagerConfigs:
+          - static_configs:
+            {{ with $url := urlParse ((.Values.foundations).cloud).alertsCollectorUri }}
+              - targets:
+                  - {{index $url "host" | quote }}
+            scheme: {{index $url "scheme" | default "https" | quote }}
+            {{ end }}
+            {{ if ((.Values.foundations).cloud).alertsCollectorPassword }}
+            basic_auth:
+              username: {{ .Values.foundations.clusterName | quote }}
+              password_file: /etc/prometheus/secrets/alerts-collector-secret/password
+            {{ end }}
+        alerting:
+          alertmanagers: []
+        {{ end }}
   install:
     createNamespace: true
   upgrade:
@@ -60,4 +88,14 @@ metadata:
 stringData:
   username: {{ .Values.foundations.clusterName | quote }}
   password: {{ .Values.foundations.cloud.metricsCollectorPassword | quote }}
+{{ end }}
+---
+{{ if and ((.Values.foundations).cloud).alertsCollectorUri .Values.foundations.cloud.alertsCollectorPassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: foundations
+  name: alerts-collector-secret
+stringData:
+  password: {{ .Values.foundations.cloud.alertsCollectorPassword | quote }}
 {{ end }}

--- a/charts/foundations/tests/prometheus_test.yaml
+++ b/charts/foundations/tests/prometheus_test.yaml
@@ -1,0 +1,108 @@
+suite: test prometheus configuration
+templates:
+  - prometheus.yaml
+tests:
+  - it: should disable alertmanager when alertsCollectorUri is set
+    documentSelector:
+      path: "apiVersion"
+      value: "helm.toolkit.fluxcd.io/v2"
+    set:
+      foundations.cloud.alertsCollectorUri: "http://example.com"
+    asserts:
+      - equal:
+          path: spec.values.alertmanager.enabled
+          value: false
+
+  - it: should enable alertmanager when alertsCollectorUri is not set
+    documentSelector:
+      path: "apiVersion"
+      value: "helm.toolkit.fluxcd.io/v2"
+    set:
+      foundations.cloud.alertsCollectorUri: null
+    asserts:
+      - equal:
+          path: spec.values.alertmanager.enabled
+          value: true
+
+  - it: should set correct cluster name in external labels
+    documentSelector:
+      path: "apiVersion"
+      value: "helm.toolkit.fluxcd.io/v2"
+    set:
+      foundations.clusterName: "test-cluster"
+    asserts:
+      - equal:
+          path: spec.values.prometheus.prometheusSpec.externalLabels.cluster
+          value: "test-cluster"
+
+  - it: should configure remoteWrite when metricsCollectorUri is set
+    documentSelector:
+      path: "apiVersion"
+      value: "helm.toolkit.fluxcd.io/v2"
+    set:
+      foundations.cloud.metricsCollectorUri: "http://metrics-collector.example.com"
+      foundations.clusterName: "test-cluster"
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.values.prometheus.prometheusSpec.remoteWrite
+      - equal:
+          path: spec.values.prometheus.prometheusSpec.remoteWrite[0].url
+          value: "http://metrics-collector.example.com"
+      - equal:
+          path: spec.values.prometheus.prometheusSpec.remoteWrite[0].headers.X-Scope-OrgID
+          value: "test-cluster"
+
+  - it: should include basicAuth when metricsCollectorPassword is set
+    documentSelector:
+      path: "apiVersion"
+      value: "helm.toolkit.fluxcd.io/v2"
+    set:
+      foundations.cloud.metricsCollectorUri: "http://metrics-collector.example.com"
+      foundations.cloud.metricsCollectorPassword: "secret-password"
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.values.prometheus.prometheusSpec.remoteWrite[0].basicAuth
+
+  - it: should configure additionalAlertManagerConfigs when alertsCollectorUri is set
+    documentSelector:
+      path: "apiVersion"
+      value: "helm.toolkit.fluxcd.io/v2"
+    set:
+      foundations.cloud.alertsCollectorUri: "https://alerts-collector.example.com"
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.values.prometheus.prometheusSpec.additionalAlertManagerConfigs
+      - equal:
+          path: spec.values.prometheus.prometheusSpec.additionalAlertManagerConfigs[0].static_configs[0].targets[0]
+          value: "alerts-collector.example.com"
+      - equal:
+          path: spec.values.prometheus.prometheusSpec.additionalAlertManagerConfigs[0].scheme
+          value: "https"
+
+  - it: should create metrics-collector-secret when metricsCollectorPassword is set
+    documentSelector:
+      path: metadata.name
+      value: metrics-collector-secret
+    set:
+      foundations.cloud.metricsCollectorUri: "http://metrics-collector.example.com"
+      foundations.cloud.metricsCollectorPassword: "secret-password"
+      foundations.clusterName: "test-cluster"
+    asserts:
+      - equal:
+          path: stringData.username
+          value: "test-cluster"
+      - equal:
+          path: stringData.password
+          value: "secret-password"
+
+  - it: should create alerts-collector-secret when alertsCollectorPassword is set
+    documentSelector:
+      path: metadata.name
+      value: alerts-collector-secret
+    set:
+      foundations.cloud.alertsCollectorUri: "https://alerts-collector.example.com"
+      foundations.cloud.alertsCollectorPassword: "alerts-secret"
+    asserts:
+      - equal:
+          path: stringData.password
+          value: "alerts-secret"

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -12,7 +12,5 @@ foundations:
   #   publicIPs:
   #     - cidr: 192.168.181.1/32
   #     - cidr: 192.168.181.2/32
-  #   metricsCollectorUri: "https://<cortex>"
+  #   metricsCollectorUri: "http://<cortex>"
   #   metricsCollectorPassword: ""
-  #   alertsCollectorUri: "https://<alertmanager.example.com>"
-  #   alertsCollectorPassword: ""

--- a/foundations/config.yaml
+++ b/foundations/config.yaml
@@ -12,5 +12,7 @@ foundations:
   #   publicIPs:
   #     - cidr: 192.168.181.1/32
   #     - cidr: 192.168.181.2/32
-  #   metricsCollectorUri: "http://<cortex>"
+  #   metricsCollectorUri: "https://<cortex>"
   #   metricsCollectorPassword: ""
+  #   alertsCollectorUri: "https://<alertmanager.example.com>"
+  #   alertsCollectorPassword: ""

--- a/foundations/foundations.yaml
+++ b/foundations/foundations.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    semver: "0.1.x"
+    semver: "0.2.x"
   url: https://github.com/kraudcloud/foundations.git
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
Instead of using an default local alertmanager without targets, it would be better if we could have the ability to centralize our alerting systems, which makes it far easier to handle silences, as well as avoiding to spread secrets for configuration.